### PR TITLE
Ft collision preview

### DIFF
--- a/src/GameCollection/ICollectionEntry.h
+++ b/src/GameCollection/ICollectionEntry.h
@@ -3,12 +3,50 @@
 
 namespace GameCollection
 {
+	/*
+		Every entry/module in/for GameCollection like "Menu" or "Tetris" needs to implement this
+		interface-like Class.
+
+		> Common main-loop is 
+
+		while (window.isOpen()) {
+			while (window.pollEvent(event)) {
+				if (event.type == sf::Event::Closed)
+					window.close();
+				else if (event.type == sf::Event::KeyPressed)
+		!			collectionEntry.handleEvent(event);
+			}
+		!	collectionEntry.handleTime();
+			window.clear();
+		!	collectionEntry.draw(&window);
+			window.display();
+		}
+	*/
 	class ICollectionEntry
 	{
 	public:
-		virtual void handleEvent(const sf::Event& sfevent) = 0;
+		/*
+			-- PureVirtual -- 
+			Every entry have to handle keyboard and/or mouse events. 
+			It will called right before draw method.
+		*/
+		virtual void handleEvent(const sf::Event sfevent) = 0;
+		
+		/*
+			This method will directly called after "handleEvent" outside the window.pollEvent loop.
+			It should handle something like time/tick or other game rythmics. It will be called every
+			loop right before the draw-method and before window.display(). There is no need to 
+			override this method if its not needed (in a case like "Menu" entry, where is no need
+			for any time/game rythmic). 
+		*/
 		virtual void handleTime() {}
-		virtual void draw(sf::RenderWindow& window) = 0;
+		
+		/*
+			--PureVirtual -- 
+			Since this project is based on SFML, this method should draw every needed item/object 
+			to the given window. This method will be called every frime right before displaying the window.  
+		*/
+		virtual void draw(sf::RenderWindow* window) = 0;
 	};
 }
 

--- a/src/GameCollection/Tetris/Game.cpp
+++ b/src/GameCollection/Tetris/Game.cpp
@@ -1,0 +1,107 @@
+#include "Game.h"
+#include <iostream>
+
+/*
+Draws the blocks of the Playfield grid and the tetromino.
+Creates sf::RectangleShape's, assigns them the colors saved in the
+Playfield's grid / shape colors and sets them to their corresponding position.
+
+Example usage:
+window.clear();
+playfield.draw(tetromino);
+window.diplay();
+*/
+void TetrisGame::Game::draw(sf::RenderWindow* window)
+{
+	m_playfield->drawGrid(window);
+	m_playfield->drawTetromino(window, m_currentTetromino);
+}
+
+/*
+	Generates a random tetromino type out of Tetromino::TETROMINO_TYPE and returns it.
+*/
+TetrisGame::Tetromino::TETROMINO_TYPE TetrisGame::Game::generateRandom()
+{
+	Tetromino::TETROMINO_TYPE randomTetrominoType = static_cast<Tetromino::TETROMINO_TYPE>(rand() % Tetromino::END);
+	return randomTetrominoType;
+}
+
+
+void TetrisGame::Game::handleEvent(const sf::Event sfevent)
+{
+
+	if (m_state == GAMEOVER)
+		return;
+	
+	if (!isPosValid()) {
+		m_playfield->addTetromino(m_currentTetromino);
+		m_currentTetromino = Tetromino(Tetromino::Z, Tetromino::PLAYFIELD_POS);
+		return;
+	}
+
+
+	switch (sfevent.key.code) {
+	case sf::Keyboard::Space:
+		m_currentTetromino.rotate(Tetromino::FORWARD);
+		if (!isPosValid())
+			m_currentTetromino.rotate(Tetromino::BACKWARD);
+		break;
+	case sf::Keyboard::A:
+		m_currentTetromino.move(Tetromino::LEFT);
+		if (!isPosValid())
+			m_currentTetromino.move(Tetromino::RIGHT);
+		break;
+	case sf::Keyboard::D:
+		m_currentTetromino.move(Tetromino::RIGHT);
+		if (!isPosValid())
+			m_currentTetromino.move(Tetromino::LEFT);
+		break;
+	case sf::Keyboard::S:
+		do
+			m_currentTetromino.move(Tetromino::DOWN);
+		while (isPosValid());
+		
+		break;
+	case sf::Keyboard::P:
+		m_state = GAME_STATE::PAUSED;
+		break;
+
+	default:
+		break;
+	}
+	
+}
+
+bool TetrisGame::Game::isPosValid() 
+{
+	const sf::Vector2i* pos = &m_currentTetromino.getPosition();
+	const Tetromino::TetroShape* currentShape = &TetrisGame::Tetromino::SHAPE_DATA[m_currentTetromino.getType()][m_currentTetromino.getRotation()];
+
+	// other tetrominos
+	// iterate the 4x4 tetroshape
+	for (uint y = 0; y < 4; y++) {
+		for (uint x = 0; x < 4; x++) {
+
+			// if there is something other than zero, there is one part/block of the tetromino 
+			if (currentShape[0][y][x] == 1) {
+				// this position in the array + the position of the hole tetromino indicates 
+				// a valid position in the color-grid of playfield.
+				// if there is something other than black, a tetromino color was filled there before
+				// => indicates a collision
+
+				if (pos->x + x < 0)
+					return false;
+				else if (pos->x + x > Playfield::s_COLUMNS - 1)
+					return false;
+				else if (pos->y + y > Playfield::s_ROWS - 1)
+					return false;
+
+				if (m_playfield->getColorOfField(pos->y + y, pos->x + x) != sf::Color::Black)
+					return false;
+			}
+		}
+	}
+
+	// return true if no if-condition is true
+	return true;
+}

--- a/src/GameCollection/Tetris/Game.cpp
+++ b/src/GameCollection/Tetris/Game.cpp
@@ -1,6 +1,11 @@
 #include "Game.h"
 #include <iostream>
 
+void TetrisGame::Game::handleTime()
+{
+
+}
+
 /*
 Draws the blocks of the Playfield grid and the tetromino.
 Creates sf::RectangleShape's, assigns them the colors saved in the
@@ -14,7 +19,8 @@ window.diplay();
 void TetrisGame::Game::draw(sf::RenderWindow* window)
 {
 	m_playfield->drawGrid(window);
-	m_playfield->drawTetromino(window, m_currentTetromino);
+	m_playfield->drawTetromino(window, m_currentTetromino, false);
+	m_playfield->drawTetromino(window, m_collisionPreview, true);
 }
 
 /*
@@ -69,13 +75,43 @@ void TetrisGame::Game::handleEvent(const sf::Event sfevent)
 	default:
 		break;
 	}
-	
+
+	m_collisionPreview = m_currentTetromino;
+
+	do
+		m_collisionPreview.move(Tetromino::DOWN);
+	while (isPosValid(&m_collisionPreview));
 }
 
-bool TetrisGame::Game::isPosValid() 
+/*
+	Calls the method isPosValid(Tetromino* tetromino with the member variable
+	m_currentTetromino. This method is just for clarity and defines the default 
+	tetromino if someone want to know if the position is valid.
+*/
+bool TetrisGame::Game::isPosValid()
 {
-	const sf::Vector2i* pos = &m_currentTetromino.getPosition();
-	const Tetromino::TetroShape* currentShape = &TetrisGame::Tetromino::SHAPE_DATA[m_currentTetromino.getType()][m_currentTetromino.getRotation()];
+	return isPosValid(&m_currentTetromino);
+}
+
+/*
+	Returns a boolean if the position of the given tetromino-pointer
+	is valid or not. Invalid means, the tetromino is somewhere where it
+	should not be (outside the field or inside an another tetromino => collision).
+	If this method returns true, everything is fine. 
+
+	Example Usage: 
+		Tetromino currentTetromino = Tetromino(...);
+		currentTetromino.move(Tetromino::RIGHT);
+		if (game.isPosValid(&tetromino))
+			// ok
+		else
+			currentTetromino.move(Tetromino::LEFT);
+			// position invalid! left wall? or something?
+*/
+bool TetrisGame::Game::isPosValid(Tetromino* tetromino) 
+{
+	const sf::Vector2i* pos = &tetromino->getPosition();
+	const Tetromino::TetroShape* currentShape = &TetrisGame::Tetromino::SHAPE_DATA[tetromino->getType()][tetromino->getRotation()];
 
 	// other tetrominos
 	// iterate the 4x4 tetroshape
@@ -93,7 +129,7 @@ bool TetrisGame::Game::isPosValid()
 					return false;
 				else if (pos->x + x > Playfield::s_COLUMNS - 1)
 					return false;
-				else if (pos->y + y > Playfield::s_ROWS - 1)
+				else if (pos->y + y > Playfield::s_ROWS - 2)
 					return false;
 
 				if (m_playfield->getColorOfField(pos->y + y, pos->x + x) != sf::Color::Black)

--- a/src/GameCollection/Tetris/Game.h
+++ b/src/GameCollection/Tetris/Game.h
@@ -13,14 +13,16 @@ namespace TetrisGame
 
 	private:
 		GAME_STATE m_state;
-		TetrisGame::Tetromino m_currentTetromino;
-		TetrisGame::Tetromino m_previewTetromino;
-		Playfield* m_playfield;
+		Tetromino m_currentTetromino;
+		Tetromino m_previewTetromino;
+		Tetromino m_collisionPreview;
+		Playfield * m_playfield;
+		
 		int m_level;
 		sf::Clock m_clock;
 
 	public:
-		Game() : m_state(Game::PLAYING), m_currentTetromino(generateRandom(), TetrisGame::Tetromino::PLAYFIELD_POS), m_previewTetromino(generateRandom(), TetrisGame::Tetromino::PREVIEW_POS) {}
+		Game() : m_state(Game::PLAYING), m_currentTetromino(generateRandom(), Tetromino::PLAYFIELD_POS), m_previewTetromino(generateRandom(), Tetromino::PREVIEW_POS), m_collisionPreview(m_currentTetromino) {}
 		~Game() {}
 
 		void handleTime() {};
@@ -28,6 +30,7 @@ namespace TetrisGame
 		void handleEvent(const sf::Event sfevent);
 
 		bool isPosValid();
+		bool isPosValid(Tetromino* tetromino);
 		Tetromino::TETROMINO_TYPE generateRandom();
 	};
 

--- a/src/GameCollection/Tetris/Game.h
+++ b/src/GameCollection/Tetris/Game.h
@@ -23,14 +23,12 @@ namespace TetrisGame
 		Game() : m_state(Game::PLAYING), m_currentTetromino(generateRandom(), TetrisGame::Tetromino::PLAYFIELD_POS), m_previewTetromino(generateRandom(), TetrisGame::Tetromino::PREVIEW_POS) {}
 		~Game() {}
 
-		void handleTime();
-		void draw();
-		void handleEvent(sf::Event sfevent);
+		void handleTime() {};
+		void draw(sf::RenderWindow* window);
+		void handleEvent(const sf::Event sfevent);
 
 		bool isPosValid();
 		Tetromino::TETROMINO_TYPE generateRandom();
 	};
 
 }
-
-

--- a/src/GameCollection/Tetris/Playfield.cpp
+++ b/src/GameCollection/Tetris/Playfield.cpp
@@ -121,6 +121,8 @@ void TetrisGame::Playfield::drawGrid(sf::RenderWindow* window)
 				// Create the blocks as sf::RectangleShape's and assign color and position
 				sf::RectangleShape block(sf::Vector2f(m_BLOCK_SIZE, m_BLOCK_SIZE));
 				block.setFillColor(m_grid[y][x]);
+				block.setOutlineColor(sf::Color::Black);
+				block.setOutlineThickness(1);
 				block.setPosition(x * m_BLOCK_SIZE + s_OFFSET, y * m_BLOCK_SIZE + s_OFFSET);
 
 				// Call draw-function of window

--- a/src/GameCollection/Tetris/Playfield.cpp
+++ b/src/GameCollection/Tetris/Playfield.cpp
@@ -142,7 +142,7 @@ void TetrisGame::Playfield::drawGrid(sf::RenderWindow* window)
 		// in this specific case, the playfield should contain other offsets
 		// so they will be drawn alongsite eachother
 */
-void TetrisGame::Playfield::drawTetromino(sf::RenderWindow* window, TetrisGame::Tetromino & tetromino)
+void TetrisGame::Playfield::drawTetromino(sf::RenderWindow* window, TetrisGame::Tetromino & tetromino, bool transparency)
 {
 	// Draw tetromino
 	// Get tetromino shape
@@ -161,7 +161,14 @@ void TetrisGame::Playfield::drawTetromino(sf::RenderWindow* window, TetrisGame::
 				sf::RectangleShape tetroBlock(sf::Vector2f(38, 38));
 
 				// Assign the respective color to the shape
-				tetroBlock.setFillColor(TetrisGame::Tetromino::SHAPE_COLORS[tetromino.getType()]);
+				if (transparency) {
+					tetroBlock.setFillColor(sf::Color::Transparent);
+					tetroBlock.setOutlineColor(sf::Color::White);
+					tetroBlock.setOutlineThickness(1);
+				} 
+				else {
+					tetroBlock.setFillColor(TetrisGame::Tetromino::SHAPE_COLORS[tetromino.getType()]);
+				}
 
 				// Calculate the on-screen position of the block
 				tetrominoBlockPosition.x = (tetromino.getPosition().x + x) * m_BLOCK_SIZE + s_OFFSET;

--- a/src/GameCollection/Tetris/Playfield.h
+++ b/src/GameCollection/Tetris/Playfield.h
@@ -29,7 +29,7 @@ namespace TetrisGame
 		sf::Color getColorOfField(uint y, uint x);
 
 		void drawGrid(sf::RenderWindow* window);
-		void drawTetromino(sf::RenderWindow* window, TetrisGame::Tetromino& tetromino);
+		void drawTetromino(sf::RenderWindow* window, TetrisGame::Tetromino& tetromino, bool transparency);
 
 
 	};


### PR DESCRIPTION
### Summary:
Now its possible to spawn and move (right,left,down) an Tetromino. It will added to the playfield grid, if there is a collision with other blocks inside the playfield. 

### Improvements:
- added some documentation
- collision preview feature: it will preview the collision of the current tetromino with other block inside the playfield

